### PR TITLE
FOLIO-1253 generate-api-docs args

### DIFF
--- a/vars/buildMvn.groovy
+++ b/vars/buildMvn.groovy
@@ -131,7 +131,7 @@ def call(body) {
         if (config.publishAPI ==~ /(?i)(Y|YES|T|TRUE)/) {
           stage('Publish API Docs') {
             echo "Publishing API docs"
-            sh "python3 /usr/local/bin/generate_api_docs.py -r $env.project_name -v -o folio-api-docs"
+            sh "python3 /usr/local/bin/generate_api_docs.py -r $env.project_name -l info -o folio-api-docs"
             withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', 
                  accessKeyVariable: 'AWS_ACCESS_KEY_ID', 
                  credentialsId: 'jenkins-aws', 

--- a/vars/buildNPM.groovy
+++ b/vars/buildNPM.groovy
@@ -165,7 +165,7 @@ def call(body) {
           if (config.publishAPI ==~ /(?i)(Y|YES|T|TRUE)/) {
             stage('Publish API Docs') {
               echo "Publishing API docs"
-              sh "python3 /usr/local/bin/generate_api_docs.py -r $env.project_name -v -o folio-api-docs"
+              sh "python3 /usr/local/bin/generate_api_docs.py -r $env.project_name -l info -o folio-api-docs"
               withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                    credentialsId: 'jenkins-aws',


### PR DESCRIPTION
For generate-api-docs job, use new arg `—loglevel` rather than `—verbose`