### PR TITLE
FOLIO-2237 improve minimal dockerhub readme

### DIFF
--- a/vars/buildJavaDocker.groovy
+++ b/vars/buildJavaDocker.groovy
@@ -128,21 +128,12 @@ EOF
           sh "docker push ${env.dockerRepo}/${env.name}:latest"
         }
         // publish readme
-        /* FOLIO-2237 move code to enable test branch build
         echo "Publish Readme Docker Hub"
         withCredentials([usernamePassword(credentialsId: 'DockerHubIDJenkins', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
           writeFile file: 'dockerHubPublishMetadata.sh', text: libraryResource('org/folio/dockerHubPublishMetadata.sh')
           sh 'chmod +x dockerHubPublishMetadata.sh'
           sh "./dockerHubPublishMetadata.sh ${env.dockerRepo}/${env.name} ${env.projectName} ${env.projUrl}"
         }
-        */
-      }
-      echo "Publish Readme Docker Hub"
-      // FOLIO-2237 enable test branch build
-      withCredentials([usernamePassword(credentialsId: 'DockerHubIDJenkins', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-        writeFile file: 'dockerHubPublishMetadata.sh', text: libraryResource('org/folio/dockerHubPublishMetadata.sh')
-        sh 'chmod +x dockerHubPublishMetadata.sh'
-        sh "./dockerHubPublishMetadata.sh ${env.dockerRepo}/${env.name} ${env.projectName} ${env.projUrl}"
       }
     } // end dir()
 


### PR DESCRIPTION
Now uses information from the MD launchDescriptor, rather than MD "metadata" section.
Also handles missing launchDescriptor or missing LD properties.

Tested via branch of mod-notes (has DB), and mod-codex-mux (no DB), and some others locally.