### PR TITLE
FOLIO-2237 improve minimal dockerhub readme 2

### DIFF
--- a/vars/buildJavaDocker.groovy
+++ b/vars/buildJavaDocker.groovy
@@ -133,14 +133,12 @@ EOF
           sh "docker push ${env.dockerRepo}/${env.name}:latest"
         }
         // publish readme
-        /* FOLIO-2237 temporarily move code to enable test branch build
         echo "Publish Readme Docker Hub"
         withCredentials([usernamePassword(credentialsId: 'DockerHubIDJenkins', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
           writeFile file: 'dockerHubPublishMetadata.sh', text: libraryResource('org/folio/dockerHubPublishMetadata.sh')
           sh 'chmod +x dockerHubPublishMetadata.sh'
           sh "./dockerHubPublishMetadata.sh ${env.dockerRepo}/${env.name} ${env.projectName} ${env.projUrl}"
         }
-        */
       } else if (env.CHANGE_ID && publishPreview) {
         echo "Publishing Preview Docker images"
         def previewId = "${env.bareVersion}.${env.CHANGE_ID}.${env.BUILD_NUMBER}"
@@ -148,13 +146,6 @@ EOF
           sh "docker tag ${env.name}:${env.version} docker-registry.ci.folio.org/${env.name}:${previewId}"
           sh "docker push docker-registry.ci.folio.org/${env.name}:${previewId}"
         }
-      }
-      echo "Publish Readme Docker Hub"
-      // FOLIO-2237 enable test branch build
-      withCredentials([usernamePassword(credentialsId: 'DockerHubIDJenkins', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-        writeFile file: 'dockerHubPublishMetadata.sh', text: libraryResource('org/folio/dockerHubPublishMetadata.sh')
-        sh 'chmod +x dockerHubPublishMetadata.sh'
-        sh "./dockerHubPublishMetadata.sh ${env.dockerRepo}/${env.name} ${env.projectName} ${env.projUrl}"
       }
     } // end dir()
 


### PR DESCRIPTION
Now also shows any extra environment variables from the MD launchDescriptor, and any JAVA_OPTIONS.

Tested via branch of mod-notes (has DB), and mod-codex-mux (no DB), and mod-source-record-storage (extra env), and some others locally.