### PR TITLE
FOLIO-1447 lint-raml: Append extra message when errors

### DIFF
--- a/vars/runLintRamlCop.groovy
+++ b/vars/runLintRamlCop.groovy
@@ -26,11 +26,12 @@ def call() {
   if (lintStatus != 0) {
     echo "Issues detected:"
     echo "$lintReport"
+    def message = "$lintReport\n\nNote: When those errors are fixed, then the INFO messages will be gone too. See Jenkins \"Artifacts\" tab."
     // PR
     if (env.CHANGE_ID) {
       // Requires https://github.com/jenkinsci/pipeline-github-plugin
       @NonCPS
-      def comment = pullRequest.comment(lintReport)
+      def comment = pullRequest.comment(message)
     }
   }
   else {

--- a/vars/runLintRamlSchema.groovy
+++ b/vars/runLintRamlSchema.groovy
@@ -27,11 +27,12 @@ def call() {
   if (lintStatus != 0) {
     echo "Issues detected:"
     echo "$lintReport"
+    def message = "$lintReport\n\nNote: When those errors are fixed, then the INFO messages will be gone too. See Jenkins \"Artifacts\" tab."
     // PR
     if (env.CHANGE_ID) {
       // Requires https://github.com/jenkinsci/pipeline-github-plugin
       @NonCPS
-      def comment = pullRequest.comment(lintReport)
+      def comment = pullRequest.comment(message)
     }
   }
   else {


### PR DESCRIPTION
Emphasise that when errors are fixed, then info messages not shown on PR.

Tested via mod-courses/pull/14