### PR TITLE
Delete tenant script

### DIFF
--- a/vars/deleteTenant.groovy
+++ b/vars/deleteTenant.groovy
@@ -1,0 +1,27 @@
+#/usr/bin/env groovy
+
+
+/*
+ * purge and delete FOLIO tenant in k8s
+ */
+
+
+def call(String targetOkapi, String targetTenant) {
+
+  env.okapiToken = ''
+
+  httpRequest acceptType: 'APPLICATION_JSON_UTF8',
+              contentType: 'APPLICATION_JSON_UTF8',
+              consoleLogResponseBody: false,
+              httpMode: 'GET',
+              validResponseCodes: '200',
+              outputFile:  "tenants.json",
+              customHeaders: [[maskValue: true,name: 'X-Okapi-Token',value: env.okapiToken],
+                             [maskValue: false,name: 'X-Okapi-Tenant',value: 'supertenant']],
+              url: "${targetOkapi}/_/proxy/tenants/${targetTenant}"
+
+  sh "cat tenatns.json"
+
+  return(true)
+
+}

--- a/vars/deleteTenant.groovy
+++ b/vars/deleteTenant.groovy
@@ -57,13 +57,12 @@ def call(String targetOkapi, String targetTenant, Boolean secured = true) {
                                 [maskValue: false,name: 'X-Okapi-Tenant',value: 'supertenant']],
                 httpMode: 'DELETE',
                 validResponseCodes: '204',
-              result  url: "${targetOkapi}/_/proxy/tenants/${targetTenant}"
+                url: "${targetOkapi}/_/proxy/tenants/${targetTenant}"
 
-    def result = "deleted tenant ${targetTenant}"
+    echo "deleted tenant ${targetTenant}"
   } else {
-    def result = "tenant ${targetTenant} does not exist, skipping deletion..."
+    echo "tenant ${targetTenant} does not exist, skipping deletion..."
   }
 
-  return(result)
-
+  return(true)
 }

--- a/vars/deleteTenant.groovy
+++ b/vars/deleteTenant.groovy
@@ -1,4 +1,4 @@
-#/usr/bin/env groovy
+#!/usr/bin/env groovy
 
 
 /*
@@ -6,21 +6,38 @@
  */
 
 
-def call(String targetOkapi, String targetTenant) {
+def call(String targetOkapi, String targetTenant, Boolean secured = true) {
 
-  env.okapiToken = ''
+  if (secured) {
+    writeFile file: 'getOkapiToken.sh', text: libraryResource('org/folio/getOkapiToken.sh')
+    sh 'chmod +x getOkapiToken.sh' 
+    env.okapiToken = sh(returnStdout: true, script: "./getOkapiToken.sh -t supertenant -o $targetOkapi -u $user -p $pass").trim()
+  }
+
+  echo "${env.okapiToken}"
 
   httpRequest acceptType: 'APPLICATION_JSON_UTF8',
               contentType: 'APPLICATION_JSON_UTF8',
               consoleLogResponseBody: false,
               httpMode: 'GET',
               validResponseCodes: '200',
-              outputFile:  "tenants.json",
+              outputFile:  "mods-enabled.json",
               customHeaders: [[maskValue: true,name: 'X-Okapi-Token',value: env.okapiToken],
                              [maskValue: false,name: 'X-Okapi-Tenant',value: 'supertenant']],
-              url: "${targetOkapi}/_/proxy/tenants/${targetTenant}"
+              url: "${targetOkapi}/_/proxy/tenants/${targetTenant}/modules"
 
-  sh "cat tenatns.json"
+  sh "cat mods-enabled.json | jq '[.[] + {\"action\" : \"disable\"}]' > disable.json"
+  sh "cat disable.json"
+
+  //httpRequest acceptType: 'APPLICATION_JSON_UTF8',
+  //            contentType: 'APPLICATION_JSON_UTF8',
+  //            consoleLogResponseBody: false,
+  //            customHeaders: [[maskValue: true,name: 'X-Okapi-Token',value: env.okapiToken], 
+  //                            [maskValue: false,name: 'X-Okapi-Tenant',value: 'supertenant']],
+  //            httpMode: 'POST',
+  //            validResponseCodes: '200',
+  //            requestBody: "{ \"urls\" : [ \"${defaultOkapiUrl}\" ]}",
+  //            url: "${previewOkapiUrl}/_/proxy/pull/modules"
 
   return(true)
 

--- a/vars/deleteTenant.groovy
+++ b/vars/deleteTenant.groovy
@@ -20,7 +20,7 @@ def call(String targetOkapi, String targetTenant, Boolean secured = true) {
               contentType: 'APPLICATION_JSON_UTF8',
               consoleLogResponseBody: false,
               httpMode: 'GET',
-              validResponseCodes: '404',
+              validResponseCodes: '200,404',
               customHeaders: [[maskValue: true,name: 'X-Okapi-Token',value: env.okapiToken],
                              [maskValue: false,name: 'X-Okapi-Tenant',value: 'supertenant']],
               url: "${targetOkapi}/_/proxy/tenants/${targetTenant}"
@@ -63,6 +63,4 @@ def call(String targetOkapi, String targetTenant, Boolean secured = true) {
   } else {
     echo "tenant ${targetTenant} does not exist, skipping deletion..."
   }
-
-  return(true)
 }


### PR DESCRIPTION
Adds script for deleting tenants given a tenant id and an okapi url. will:
* check if tenant exists
* if tenant exists, get a list of enabled modules and format for disabling
* post the list to the install endpoint with `purge=true`.
* delete the tenant

should be idempotent (i.e. can be called safely on non-existent tenants).

Can be invoked for a secured okapi by wrapping with credentials:

```
withCredentials([usernamePassword(credentialsId: 'some-creds', passwordVariable: 'pass', usernameVariable: 'user')]) {
            deleteTenant("https://okapi-default.ci.folio.org", "platform_core_552_5")
}
```
or without by setting the last parameter to false:
```
deleteTenant("https://okapi-default.ci.folio.org", "platform_core_552_5", false)
```


test is set up temporarily at: https://jenkins-aws.indexdata.com/job/folio-org/job/ci-test-repo/job/delete-tenant/