### PR TITLE
FOLIO-2674 Archive cypress on failure via runScripts too

### DIFF
--- a/vars/runNPMScript.groovy
+++ b/vars/runNPMScript.groovy
@@ -41,6 +41,14 @@ def call(String scriptName, String scriptArgs) {
           @NonCPS
           comment = pullRequest.comment(errorMessage)
         }
+        // archive cypress artifacts if they exist
+        if (fileExists('cypress/artifacts')) {
+          sh 'tar -zcf cypress.tar.gz --directory cypress artifacts'
+          archiveArtifacts artifacts: 'cypress.tar.gz', allowEmptyArchive: true
+        }
+        else {
+          echo "No cypress artifacts to be archived."
+        }
         error(errorMessage)
       }
     } 


### PR DESCRIPTION
This now happens via the runScripts or runTest Jenkins job, whichever is used.

See [FOLIO-2674](https://issues.folio.org/browse/FOLIO-2674)