### PR TITLE
Exclude jest config from scanning

### DIFF
--- a/vars/sonarqubeScanNPM.groovy
+++ b/vars/sonarqubeScanNPM.groovy
@@ -1,18 +1,18 @@
 #!/usr/bin/env groovy
 
-/* 
+/*
  * Run the SonarQube scanner for JS-based projects
- * 
+ *
  */
 
 
 def call(String lcovPath = 'artifacts/coverage', String lcovPath2 = 'coverage') {
-  withCredentials([[$class: 'StringBinding', 
-                        credentialsId: '6b0ebf62-3a12-4e6b-b77e-c45817b5791b', 
+  withCredentials([[$class: 'StringBinding',
+                        credentialsId: '6b0ebf62-3a12-4e6b-b77e-c45817b5791b',
                         variable: 'GITHUB_ACCESS_TOKEN']]) {
     withSonarQubeEnv('SonarCloud') {
       def scannerHome = tool 'SonarQube-Scanner-4'
-      def excludeFiles = '**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/resources/bigtest/interactors/**,**/resources/bigtest/network/**,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js'
+      def excludeFiles = '**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/resources/bigtest/interactors/**,**/resources/bigtest/network/**,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js,**/jest.config.js'
 
       if (env.CHANGE_ID) {
         sh "${scannerHome}/bin/sonar-scanner " +
@@ -26,12 +26,12 @@ def call(String lcovPath = 'artifacts/coverage', String lcovPath2 = 'coverage') 
           "-Dsonar.pullrequest.base=master " +
           "-Dsonar.pullrequest.key=${env.CHANGE_ID} " +
           "-Dsonar.pullrequest.branch=${env.BRANCH_NAME} " +
-          "-Dsonar.pullrequest.provider=github " + 
-          "-Dsonar.pullrequest.github.repository=folio-org/${env.projectName} " 
+          "-Dsonar.pullrequest.provider=github " +
+          "-Dsonar.pullrequest.github.repository=folio-org/${env.projectName} "
           // "-Dsonar.pullrequest.github.endpoint=https://api.github.com"
       }
-      else {  
-        if (env.BRANCH_NAME != 'master' ) { 
+      else {
+        if (env.BRANCH_NAME != 'master' ) {
           sh "git fetch --no-tags ${env.projUrl} +refs/heads/master:refs/remotes/origin/master"
           sh "${scannerHome}/bin/sonar-scanner " +
             "-Dsonar.organization=folio-org " +
@@ -41,7 +41,7 @@ def call(String lcovPath = 'artifacts/coverage', String lcovPath2 = 'coverage') 
             "-Dsonar.sources=. " +
             "-Dsonar.language=js " +
             "-Dsonar.exclusions=${excludeFiles} " +
-            "-Dsonar.javascript.lcov.reportPaths=${lcovPath}/lcov.info,${lcovPath2}/lcov.info" 
+            "-Dsonar.javascript.lcov.reportPaths=${lcovPath}/lcov.info,${lcovPath2}/lcov.info"
         }
         else {
           sh "${scannerHome}/bin/sonar-scanner " +
@@ -51,7 +51,7 @@ def call(String lcovPath = 'artifacts/coverage', String lcovPath2 = 'coverage') 
             "-Dsonar.sources=. " +
             "-Dsonar.language=js " +
             "-Dsonar.exclusions=${excludeFiles} " +
-            "-Dsonar.javascript.lcov.reportPaths=${lcovPath}/lcov.info,${lcovPath2}/lcov.info"      
+            "-Dsonar.javascript.lcov.reportPaths=${lcovPath}/lcov.info,${lcovPath2}/lcov.info"
         }
       }
 


### PR DESCRIPTION
This PR adds `jest.config.js` to the `excludeFiles` list so the sonarcloud doesn't report it as an uncovered file.

Sorry for all the white space removals. It's my editor...
