### PR TITLE
Disable Sonarqube on Java 8 (jenkins-slave-all)

### DIFF
--- a/vars/buildMvn.groovy
+++ b/vars/buildMvn.groovy
@@ -143,9 +143,12 @@ def call(body) {
           }
         }
 
-        // Run Sonarqube
-        stage('SonarQube Analysis') {
-          sonarqubeMvn()
+        // Run Sonarqube,
+        // but not on jenkins-slave-all as Sonarqube no longer supports Java 8
+        if (buildNode != 'jenkins-slave-all') {
+          stage('SonarQube Analysis') {
+            sonarqubeMvn()
+          }
         }
 
         if ( env.isRelease && fileExists(modDescriptor) ) {
@@ -160,7 +163,7 @@ def call(body) {
             echo "Building Docker image for $env.name:$env.version"
             config.doDocker.delegate = this
             config.doDocker.resolveStrategy = Closure.DELEGATE_FIRST
-	    config.doDocker.call()
+            config.doDocker.call()
           }
         }
 


### PR DESCRIPTION
Builds that require Java 8 need to disable Sonarqube checks because Sonarqube requires Java >= 11.

Example failure message from https://jenkins-aws.indexdata.com/job/folio-org/job/vertx-sql-client/view/tags/job/v4.0.2-FOLIO/ :

```
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar (default-cli) on project vertx-sql-client-parent:
[ERROR]
[ERROR] The version of Java (1.8.0_252) you have used to run this analysis is deprecated and we stopped accepting it. Please update to at least Java 11.
[ERROR] Temporarily you can set the property 'sonar.scanner.force-deprecated-java-version-grace-period' to 'true' to continue using Java 1.8.0_252
[ERROR] This will only work until Mon Feb 15 09:00:00 UTC 2021, afterwards all scans will fail.
[ERROR] You can find more information here: https://sonarcloud.io/documentation/upcoming/
```