### PR TITLE
Increase node memory limit to 4gb

### DIFF
--- a/vars/runTestNPM.groovy
+++ b/vars/runTestNPM.groovy
@@ -2,34 +2,34 @@
 
 
 /*
- * Run Node/NPM-based "unit" tests.  
- * 
+ * Run Node/NPM-based "unit" tests.
+ *
  * Example:
  *
- * buildNPM { 
+ * buildNPM {
  *   runTest = 'yes'
  *   runTestOptions = '--karma.singleRun --karma.browsers=ChromeDocker'
  * }
- * 
+ *
  */
 
 def call(String runTestOptions = '') {
 
   stage('Run Local Tests') {
-   
+
     def XVFB = 'xvfb-run --server-args="-screen 0 1024x768x24"'
 
-    env.NODE_OPTIONS="--max-old-space-size=3076"
+    env.NODE_OPTIONS="--max-old-space-size=4096"
     sh "echo NODE_OPTIONS=$NODE_OPTIONS"
 
-    withEnv([ 
+    withEnv([
       'CHROME_BIN=/usr/bin/google-chrome-stable',
       'FIREFOX_BIN=/usr/bin/firefox',
       'DEBIAN_FRONTEND=noninteractive',
       'JEST_JUNIT_OUTPUT_DIR=./artifacts/jest-junit'
-    ]) { 
+    ]) {
 
-      // disabled since we build new build images every week. 
+      // disabled since we build new build images every week.
       // get latest versions for browsers
       // sh 'sudo apt-get -q update'
       // sh 'sudo apt-get -y --no-install-recommends install google-chrome-stable'
@@ -41,13 +41,13 @@ def call(String runTestOptions = '') {
 
       def testStatus = sh(returnStatus:true, script: "$XVFB yarn test $runTestOptions")
 
-      if (testStatus != 0) { 
+      if (testStatus != 0) {
         def message = "Test errors found. See ${env.BUILD_URL}"
         // PR
         if (env.CHANGE_ID) {
           // Requires https://github.com/jenkinsci/pipeline-github-plugin
           @NonCPS
-          def comment = pullRequest.comment(message) 
+          def comment = pullRequest.comment(message)
         }
         // archive cypress artifacts if they exist, and only when tests fail
         if (fileExists('cypress/videos')) {
@@ -72,6 +72,6 @@ def call(String runTestOptions = '') {
       else {
         echo "All tests completed successfully."
       }
-    } 
-  } // end stage 
+    }
+  } // end stage
 }


### PR DESCRIPTION
@ihardy @funkymalc we are running into some timeout issues with our BigTests tests in both ui-inventory and ui-users. It looks like we have a memory leak somewhere or karma (the testing tool we are using) is consuming more memory now. It's hard to know for sure but I would like to try to increase the memory limit for node to 4gb just to try it out. If this doesn't work and the tests still fail I'm happy to move it back to 3gb. 

We are also in the process of rewriting these tests so at some point the current setup will go away but for now it would be great to keep the tests running. 

Would it be possible to merge this just to try it out or does the CI box have a hard memory limit?

Thank you!