### PR TITLE
FOLIO-3494 Enable jenkins-agent-java17

### DIFF
--- a/vars/buildMvn.groovy
+++ b/vars/buildMvn.groovy
@@ -99,7 +99,7 @@ def call(body) {
 
 
 
-  def buildNode = config.buildNode ?: 'jenkins-slave-all'
+  def buildNode = config.buildNode ?: 'jenkins-agent-java11'
 
   properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '',
                                           artifactNumToKeepStr: '15',

--- a/vars/setEnvMvn.groovy
+++ b/vars/setEnvMvn.groovy
@@ -48,11 +48,11 @@ def call() {
   env.projUrl = foliociLib.getProjUrl()
 
   //set java version
-  scriptStatus = sh(returnStatus:true, script: 'test -d "/usr/lib/jvm/java-11-openjdk-amd64"')
+  scriptStatus = sh(returnStatus:true, script: 'test -d "/usr/lib/jvm/java-17-openjdk-amd64"')
   if (scriptStatus == 0) {
-    env.javaInstall = 'openjdk-11-jenkins-slave-all'
+    env.javaInstall = 'openjdk-17-jenkins-slave-all'
   } else {
-    env.javaInstall = 'openjdk-8-jenkins-slave-all'
+    env.javaInstall = 'openjdk-11-jenkins-slave-all'
   }
 
   echo "JDK: $env.javaInstall"


### PR DESCRIPTION
For Maven-based builds, use Jenkinsfile: `buildNode = 'jenkins-agent-java17'`
Default is 'jenkins-agent-java11'
Drop support for java8
See [FOLIO-3494](https://issues.folio.org/browse/FOLIO-3494)