### PR TITLE
FOLIO-3728: requirements: certifi 2022.12.7,rsa 4.9,urllib3 1.25.11

### DIFF
--- a/resources/org/folio/requirements.txt
+++ b/resources/org/folio/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.12.34
 botocore==1.15.34
 cachetools==3.1.1
-certifi==2019.9.11
+certifi==2022.12.7
 chardet==3.0.4
 docutils==0.15.2
 google-auth==1.7.0
@@ -16,8 +16,8 @@ python-dateutil==2.8.1
 PyYAML==5.4
 requests==2.22.0
 requests-oauthlib==1.2.0
-rsa==4.0
+rsa==4.9
 s3transfer==0.3.3
 six==1.13.0
-urllib3==1.25.6
+urllib3==1.25.11
 websocket-client==0.56.0


### PR DESCRIPTION
https://issues.folio.org/browse/FOLIO-3728

Upgrade certifi from 2019.9.11 to 2022.12.7 fixing Insufficient Verification of Data Authenticity:

https://nvd.nist.gov/vuln/detail/CVE-2022-23491

Upgrade rsa from 4.0 to 4.9 fixing Timing Attack and Access Restriction Bypass:

https://nvd.nist.gov/vuln/detail/CVE-2020-25658
https://nvd.nist.gov/vuln/detail/CVE-2020-13757

Upgrade urllib3 from 1.25.6 to 1.25.11 fixing HTTP Header Injection, Denial of Service (DoS), and Regular Expression Denial of Service (ReDoS):

https://nvd.nist.gov/vuln/detail/CVE-2020-26137
https://nvd.nist.gov/vuln/detail/CVE-2020-7212
https://nvd.nist.gov/vuln/detail/CVE-2021-33503