### PR TITLE
FOLIO-3907: certifi==2023.07.22 fixing CVE-2023-37920

### DIFF
--- a/resources/org/folio/requirements.txt
+++ b/resources/org/folio/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.12.34
 botocore==1.15.34
 cachetools==3.1.1
-certifi==2022.12.7
+certifi==2023.07.22
 chardet==3.0.4
 docutils==0.15.2
 google-auth==1.7.0


### PR DESCRIPTION
Upgrade certifi from 2022.12.7 to 2023.07.22.

This fixes https://nvd.nist.gov/vuln/detail/CVE-2023-37920 by removing "e-Tugra" root certificates that might have been compromised.