### PR TITLE
Fix release branch regex

### DIFF
--- a/vars/buildStripesPlatform.groovy
+++ b/vars/buildStripesPlatform.groovy
@@ -9,7 +9,7 @@ def call(String okapiUrl, String tenant, String branch='') {
 
   def foliociLib = new org.folio.foliociCommands()
 
-  if (!(branch =~ /^(renovate_)?(r|R)\d{1}-\d{4}(-(rc|RC|hotfix-\d{1}))?$/)) {
+  if (!(branch =~ /(r|R)\d-\d{4}/)) {
     sh 'rm -f yarn.lock'
   }
 


### PR DESCRIPTION
Match hotfix > 9.
Match -Consortia branches like R2-2024-Consortia.
Match not only -RC, but also -RC2, etc.
Simplify the regexp to reduce regexp maintenance.

Note that `^` and `$` have been removed so that it matches with any prefix (like `renovate_`) and any suffix (like -hotfix-2).