### PR TITLE
run "yarn install" cautiously

### DIFF
--- a/vars/buildNPM.groovy
+++ b/vars/buildNPM.groovy
@@ -145,7 +145,7 @@ def call(body) {
           withCredentials([string(credentialsId: 'jenkins-npm-folioci',variable: 'NPM_TOKEN')]) {
             withNPM(npmrcConfig: env.npmConfig) {
               stage('NPM Install') {
-                sh 'yarn install' 
+                sh 'yarn install --ignore-scripts --non-interactive' 
                 sh 'yarn list --pattern @folio'
                 // save generated yarn.lock for possible debugging
                 sh 'mkdir -p artifacts/yarn/'

--- a/vars/buildStripesPlatform.groovy
+++ b/vars/buildStripesPlatform.groovy
@@ -13,7 +13,7 @@ def call(String okapiUrl, String tenant, String branch='') {
     sh 'rm -f yarn.lock'
   }
 
-  sh 'yarn install'
+  sh 'yarn install --ignore-scripts --non-interactive'
 
   // publish generated yarn.lock for possible debugging
   sh 'mkdir -p ci'


### PR DESCRIPTION
Do not run naked `yarn install`. Include `--ignore-scripts` and `--non-interactive` to prevent third-party scripts from being allowed to run during the install process.